### PR TITLE
Placeholders and opposed rolls for macros

### DIFF
--- a/fixer.js
+++ b/fixer.js
@@ -1537,7 +1537,6 @@ function rollDice(dc) {
     var rollSum = 0;
     var nOnes = 0;
 
-
     for (var iDice = 0; iDice < parseInt(dc.dice) + additionalDice; iDice++) {
         roll[iDice] = getRandomInt(1, 6);
         hits += roll[iDice] >= 5 ? 1 : 0;
@@ -1545,7 +1544,7 @@ function rollDice(dc) {
         if (roll[iDice] == 6 && dc.ruleOfSix) {
             additionalDice += 1;
         }
-        nOnes += roll[iDice] == 1 ? 1 : 0;
+        nOnes += roll[iDice] === 1 ? 1 : 0;
     }
 
 
@@ -1559,7 +1558,7 @@ function rollDice(dc) {
     result.sum = rollSum;
     switch (args.glitch.toLowerCase()) {
         case 'classic':
-        result.glitch = nOnes >= Math.ceil((dc.dice + additionalDice) / 2);
+            result.glitch = nOnes >= Math.ceil((dc.dice + additionalDice) / 2);
             break;
         case '>u':
             result.glitch = nOnes > Math.ceil((dc.dice + additionalDice) / 2);


### PR DESCRIPTION
Limits now use parentheses instead of brackets.
Now supports using multiple terms in the opposed part of an opposed roll (though still only numerical values).
The above means that macros such as [macro: binding "magic + binding (_F) v _F + _F"] are possible
Placeholders for macros now default to 0 if not specified in the call.
This means that placeholders can add optional modifiers by using placeholders, such as [macro: binding "magic + binding + _Mod (_F) v _F + _F"]
Availability tests now report how long an item is unavailable if the test fails.
Some additional assertions to avoid crashes.