### PR TITLE
Error logging and fix for Shadowrun with no character loaded

### DIFF
--- a/fixer.js
+++ b/fixer.js
@@ -13,11 +13,6 @@ Private mode
 Export channel/user data
     To allow migration of a channel to another channel
     Or to allow a user to move all of his stuff to another channel
-
-
-    fix issue with rolls when no character loaded
-    change macros so that they are not compacted before storage
-    error output should go to log file
 */
 
 /*

--- a/fixer.js
+++ b/fixer.js
@@ -14,6 +14,10 @@ Export channel/user data
     To allow migration of a channel to another channel
     Or to allow a user to move all of his stuff to another channel
 
+
+    fix issue with rolls when no character loaded
+    change macros so that they are not compacted before storage
+    error output should go to log file
 */
 
 /*
@@ -34,6 +38,8 @@ var parseString = require('xml2js').parseString;
 var fs = require('fs');
 var TextDecoder = require('text-encoding').TextDecoder; 
 var PastebinAPI = require('better-pastebin');
+const moment = require('moment');
+var CircularJSON = require('circular-json');
 /*
 ####################################################################################
 # Discord parameters
@@ -47,14 +53,16 @@ const discordCodeBlockWrapper = '```';
 # Fixer parameters
 ####################################################################################
 */
-const versionId = '0.6.1';
+const versionId = '0.6.2';
 const games = {'SR5e':'SR5e','DnD5e':'DnD5e'};
 const outputLevels = {'minimal':1,'regular':2,'verbose':3};
 const botSavePath = 'fixer.json';
+const errorLogPath = 'error.log';
+const errorDataFolder = './errorData/';
 const commands = getChatCommandList();
 const helpTopics = getHelpTopicsList();
 const reqArgs = ['token', 'user', 'password', 'devkey', 'root'];
-const optArgs = ['glitch'];
+const optArgs = [];
 var bot = {};
 var args = {};
 /*
@@ -106,7 +114,7 @@ PastebinAPI.setDevKey(args.devkey);
 # Initialize / load bot data structure
 ####################################################################################
 */
-setupBot();
+setupBot(args);
 /*
 ####################################################################################
 # Action when bot has established connection to Discord
@@ -126,14 +134,14 @@ client.on('ready', () => {
 # Prepare for message parsing
 ####################################################################################
 */
-client.on('message', message => {
+client.on('message', message => { // TODO: check client.on('messageUpdate',oldMessage,newMessage) as well?
     // If it's not a message from this bot
-    if (message.author.id != client.user.id) {
+    if (message.author.id != client.user.id && !message.author.bot) {
         if (!(message.guild)) {
             // Private message
             //TODO: Implement private messaging stuff
         } else {
-            try {
+            try { // TODO: Bot currently listens even if it is muted. Change?
                 // find all sections in brackets (not accounting for nesting)
                 let regExDelim = new RegExp(/\[([^\]]+)\]/gi);
                 let matches = regExDelim.exec(message.content);
@@ -161,9 +169,15 @@ client.on('message', message => {
                     matches = regExDelim.exec(message.content);
                 }
             } catch (err) {
-                console.log('DETECTED ERROR in message: ' + message.content);
+                // Output error to console window
+                console.log('DETECTED UNCAUGHT ERROR in message: ' + message.content);
                 console.log(err);
-                message.reply(message,'I encountered an error parsing your message.')
+
+                // Inform user of failure
+                message.reply('I encountered an error parsing your message. An error log has been generated.')
+
+                // Write to log file
+                logMessageParsingError(message,err);
             }
         }
     }
@@ -213,7 +227,7 @@ function createMacro(message,match,command) {
 
     bot.channel[channelId].game[activeGame].user[userId].macro[alias] = {
         defaultInputs: defaultInputs,
-        body: macroString.replace(/ /g,'')
+        body: macroString
     }
     saveBotData();
     message.reply('created/updated macro with alias "' + alias + '"');
@@ -732,6 +746,57 @@ function printCommandList(message) {
 */
 /*
 ####################################################################################
+# Error logging
+####################################################################################
+*/
+function logMessageParsingError(message,caughtError) {
+    try {
+        var gameMode = getGameMode(message);
+    } catch (err) {
+        var gameMode = 'FAILED TO GET';
+    }
+
+    try {
+        var userGameData = bot.channel[message.channel.id].game[gameMode].user[message.author.id];
+    } catch (err) {
+        var userGameData = 'FAILED TO GET';
+    }
+
+    let errorMsg = 
+    moment().format('YYYY-MM-DD hh:mm:ss [GMT]ZZ')
+    + '\n\t' + 'Nonce'  + '\t' + message.nonce
+    + '\n\t' + 'Error'  + '\t' + caughtError.message
+    + '\n\t' + 'String' + '\t' + message
+    + '\n\t' + 'Author' + '\t' + message.author.username + '#' + message.author.discriminator
+    + '\n\t' + 'Server' + '\t' + message.channel.guild.name
+    + '\n\t' + 'Channel'+ '\t' + message.channel.name
+    + '\n\t' + 'Game'   + '\t' + gameMode
+    + '\n\t' + 'Error'  + '\t' + caughtError.name
+    + '\n\t' + 'Stack'  + '\t' + caughtError.stack.replace(/\n\s*/g,'\n\t\t').replace(/^[^\n]*\n\s*/,'')
+    + '\n';
+
+    let errorStruct = {
+        nonce: message.nonce,
+        error: {message: caughtError.message, stack: caughtError.stack},
+        message: message,
+        botData: bot
+    }
+
+    fs.appendFile(errorLogPath, errorMsg, (err) => {
+        if (err) throw err;
+        console.log('Appended error to error log file');
+    });
+    
+    if (!fs.existsSync(errorDataFolder)) {
+        fs.mkdirSync(errorDataFolder);    
+    }
+    fs.appendFile(errorDataFolder + message.nonce + '.log', CircularJSON.stringify(errorStruct), (err) => {
+        if (err) throw err;
+        console.log('Appended error data to error data file');
+    });
+}
+/*
+####################################################################################
 # General utility functions
 ####################################################################################
 */
@@ -922,10 +987,10 @@ function sr5RollCodeParser(message,rollCode) {
     // First count identified skills and attributes
     let nSkills = 0;
     let nAttributes = 0;
-    while (matches) {   
-        if (matches[2] && matches[2].toLowerCase() in activeSkills) { nSkills += 1; } // count skills
-        else if (matches[2] && matches[2].toUpperCase() in attributes) { nAttributes += 1; } // count attributes
-        else if (matches[2] && matches[2].toLowerCase() in sr5attributeMap) { nAttributes += 1; }; // count attributes
+    while (matches) {
+        if (activeSkills && matches[2] && matches[2].toLowerCase() in activeSkills) { nSkills += 1; } // count skills
+        else if (attributes && matches[2] && matches[2].toUpperCase() in attributes) { nAttributes += 1; } // count attributes
+        else if (attributes && matches[2] && matches[2].toLowerCase() in sr5attributeMap) { nAttributes += 1; }; // count attributes
         matches = regEx.exec(rollCode);
     }
     
@@ -935,7 +1000,7 @@ function sr5RollCodeParser(message,rollCode) {
     while (matches) {   
         let sign = matches[1].replace(/ /g,'');
         // Handle skills
-        if (matches[2] && matches[2].toLowerCase() in activeSkills) {
+        if (activeSkills && matches[2] && matches[2].toLowerCase() in activeSkills) {
             let nDice = 
                 nSkills == 1 && nAttributes == 0
                 ? activeSkills[matches[2].toLowerCase()].totalDice
@@ -944,12 +1009,12 @@ function sr5RollCodeParser(message,rollCode) {
         }
         
         // Handle attributes (short name)
-        else if (matches[2] && matches[2].toUpperCase() in attributes) {
+        else if (attributes && matches[2] && matches[2].toUpperCase() in attributes) {
             totalDice += (sign=='-' ? -1 : 1)*attributes[matches[2]].totalValue;
         }
 
         // Handle attributes (full name)
-        else if (matches[2] && matches[2].toLowerCase() in sr5attributeMap) {
+        else if (attributes && matches[2] && matches[2].toLowerCase() in sr5attributeMap) {
             totalDice += (sign=='-' ? -1 : 1)*attributes[sr5attributeMap[matches[2]]].totalValue;
         }
 
@@ -1412,7 +1477,7 @@ function printCurrentOutputSetting(message) {
 # Saving and loading information
 ####################################################################################
 */
-function setupBot() {
+function setupBot(args) {
     if (botDataExists()) {
         console.log('Found saved bot data during setup - loading it');
         loadBotData();


### PR DESCRIPTION
Fixed issue where not having a character loaded would prevent Shadowrun rolls
Now outputs error.log in root folder with human-readable entries for all otherwise uncaught errors during message parsing
Also outputs /errorData/<nonce>.log with all data as it were when the message parsing error occured
Removed glitch as optional input as it isn't supported since the major overhaul
Prepared support for the bot setup to allow using the input arguments to specify defaults
Ensured that Fixer doesn't respond to other bots
Fixed incorrect feedback to user when a message failed to be parsed
Macros are no longer compacted as this presented some issues

NOTE: new requirements: circular-json and moment